### PR TITLE
Bump required YNH version to 12.1.9

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -16,7 +16,7 @@ admindoc = "https://matrix-construct.github.io/tuwunel/"
 code = "https://github.com/matrix-construct/tuwunel"
 
 [integration]
-yunohost = ">= 12.0"
+yunohost = ">= 12.1.9"
 helpers_version = "2.1"
 architectures = [ "arm64", "amd64" ]
 multi_instance = false


### PR DESCRIPTION
## Problem

- ZSTD source

## Solution

- Require YNH 12.1.9 that supports it

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
