### PR TITLE
Align config with upstream template

### DIFF
--- a/conf/tuwunel.toml
+++ b/conf/tuwunel.toml
@@ -1,10 +1,13 @@
 ### Tuwunel Configuration
 ###
+### Any values pre-populated are the default values for said config option.
+###
 ### At the minimum, you MUST edit all the config options to your environment
 ### that say "YOU NEED TO EDIT THIS".
 ###
 ### For more information, see:
 ### https://tuwunel.chat/configuration.html
+
 
 [global]
 
@@ -26,6 +29,19 @@
 # example: "girlboss.ceo"
 #
 server_name = "__SERVER_NAME__"
+
+# This is the only directory where tuwunel will save its data, including
+# media. Note: this was previously "/var/lib/matrix-conduit".
+#
+database_path = "__INSTALL_DIR__/tuwunel-db"
+
+# Text which will be added to the end of the user's displayname upon
+# registration with a space before the text. In Conduit, this was the
+# lightning bolt emoji.
+#
+# To disable, set this to "" (an empty string).
+#
+new_user_displayname_suffix = ""
 
 # The default address (IPv4 or IPv6) tuwunel will listen on.
 #
@@ -51,9 +67,6 @@ port = __PORT__
 
 # The UNIX socket tuwunel will listen on.
 #
-# tuwunel cannot listen on both an IP address and a UNIX socket. If
-# listening on a UNIX socket, you MUST remove/comment the `address` key.
-#
 # Remember to make sure that your reverse proxy has access to this socket
 # file, either by adding your reverse proxy to the 'tuwunel' group or
 # granting world R/W permissions with `unix_socket_perms` (666 minimum).
@@ -66,14 +79,13 @@ port = __PORT__
 #
 #unix_socket_perms = 660
 
-# This is the only directory where tuwunel will save its data, including
-# media. Note: this was previously "/var/lib/matrix-conduit".
+# Error on startup if any config option specified is unknown to Tuwunel.
 #
-# YOU NEED TO EDIT THIS.
+# This is false by default to allow easier deprecation or removal of
+# config options in the future without breaking existing deployments. The
+# default behaviour is to simply warn on startup.
 #
-# example: "/var/lib/tuwunel"
-#
-database_path = "__INSTALL_DIR__/tuwunel-db"
+#error_on_unknown_config_opts = false
 
 # tuwunel supports online database backups using RocksDB's Backup engine
 # API. To use this, set a database backup path that tuwunel can write
@@ -90,14 +102,6 @@ database_path = "__INSTALL_DIR__/tuwunel-db"
 # "database_backup_path", before deleting the oldest one.
 #
 #database_backups_to_keep = 1
-
-# Text which will be added to the end of the user's displayname upon
-# registration with a space before the text. In Conduit, this was the
-# lightning bolt emoji.
-#
-# To disable, set this to "" (an empty string).
-#
-new_user_displayname_suffix = ""
 
 # Set this to any float value to multiply tuwunel's in-memory LRU caches
 # with such as "auth_chain_cache_capacity".
@@ -176,9 +180,30 @@ new_user_displayname_suffix = ""
 #
 #stateinfo_cache_capacity = varies by system
 
-# This item is undocumented. Please contribute documentation for it.
+# Minimum time-to-live in seconds for room summary entries in the spaces
+# cache.
 #
-#roomid_spacehierarchy_cache_capacity = varies by system
+#spacehierarchy_cache_ttl_min = 21600
+
+# Maximum time-to-live in seconds for room summary entries in the spaces
+# cache.
+#
+#spacehierarchy_cache_ttl_max = 129600
+
+# Minimum timeout a client can request for long-polling sync. Requests
+# will be clamped up to this value if smaller.
+#
+#client_sync_timeout_min = 5000
+
+# Default timeout for long-polling sync if a client does not request
+# another in their query-string.
+#
+#client_sync_timeout_default = 30000
+
+# Maximum timeout a client can request for long-polling sync. Requests
+# will be clamped down to this value if larger.
+#
+#client_sync_timeout_max = 90000
 
 # Maximum entries stored in DNS memory-cache. The size of an entry may
 # vary so please take care if raising this value excessively. Only
@@ -190,9 +215,10 @@ new_user_displayname_suffix = ""
 
 # Minimum time-to-live in seconds for entries in the DNS cache. The
 # default may appear high to most administrators; this is by design as the
-# majority of NXDOMAINs are correct for a long time (e.g. the server is no
-# longer running Matrix). Only decrease this if you are using an external
-# DNS cache.
+# exotic loads of federating to many other servers require a higher TTL
+# than many domains have set. Even when using an external DNS cache the
+# problem is shifted to that cache which is ignorant of its role for
+# this application and can adhere to many low TTL's increasing its load.
 #
 #dns_min_ttl = 10800
 
@@ -260,9 +286,58 @@ new_user_displayname_suffix = ""
 #
 #ip_lookup_strategy = 5
 
-# Max request size for file uploads in bytes. Defaults to 20MB.
+# List of domain patterns resolved via the alternative path without any
+# persistent cache, very small memory cache, and no enforced TTL. This
+# is intended for internal network and application services which require
+# these specific properties. This path does not support federation or
+# general purposes.
 #
-#max_request_size = 20971520
+# example: ["*\.dns\.podman$"]
+#
+#dns_passthru_domains = []
+
+# Whether to resolve appservices via the alternative path; setting this is
+# superior to providing domains in `dns_passthru_domains` if all
+# appservices intend to be matched anyway. The overhead of matching regex
+# and maintaining the list of domains can be avoided.
+#
+#dns_passthru_appservices = false
+
+# Enable or disable case randomization for DNS queries. This is a security
+# mitigation where answer spoofing is prevented by having to exactly match
+# the question. Occasional errors seen in logs which may have lead you
+# here tend to be from overloading DNS. Nevertheless for servers which
+# are truly incapable this can be set to false.
+#
+# This currently defaults to false due to user reports regarding some
+# popular DNS caches which may or may not be patched soon. It may again
+# default to true in an upcoming release.
+#
+#dns_case_randomization = false
+
+# Max request size for file uploads. Accepts an integer byte count or a
+# string with SI/IEC suffix such as "24 MiB".
+#
+#max_request_size = 24 MiB
+
+# Maximum number of concurrently pending (asynchronous) media uploads a
+# user can have.
+#
+#max_pending_media_uploads = 5
+
+# The time in seconds before an unused pending MXC URI expires and is
+# removed.
+#
+#media_create_unused_expiration_time = 86400 (24 hours)
+
+# The maximum number of media create requests per second allowed from a
+# single user.
+#
+#media_rc_create_per_second = 10
+
+# The maximum burst count for media create requests from a single user.
+#
+#media_rc_create_burst_count = 50
 
 # This item is undocumented. Please contribute documentation for it.
 #
@@ -352,7 +427,7 @@ new_user_displayname_suffix = ""
 
 # Maximum time to process a request received from a client (seconds).
 #
-#client_request_timeout = 180
+#client_request_timeout = 240
 
 # Maximum time to transmit a response to a client (seconds)
 #
@@ -361,6 +436,37 @@ new_user_displayname_suffix = ""
 # Grace period for clean shutdown of client requests (seconds).
 #
 #client_shutdown_timeout = 10
+
+# Source of the client IP address for rate limiting, logging, and
+# security tooling.
+#
+# When unset (the default), the `ClientIp` extractor falls back to
+# `axum-client-ip`'s `InsecureClientIp` for backward compatibility;
+# clients can spoof their address via request headers in that mode.
+#
+# When set, tuwunel installs `SecureClientIpSource` with the selected
+# variant and `ClientIp` resolves exclusively from that source. The
+# rightmost value is used for multi-valued headers; only the proxy can
+# append to the right, so this is resistant to client spoofing.
+#
+# Supported values:
+# - "connect_info" - TCP peer address only (direct connections)
+# - "rightmost_x_forwarded_for" - nginx, Caddy
+# - "rightmost_forwarded" - RFC 7239 proxies
+# - "x_real_ip" - nginx `X-Real-IP`
+# - "cf_connecting_ip" - Cloudflare / cloudflared
+# - "true_client_ip" - Akamai, Cloudflare Enterprise
+# - "fly_client_ip" - Fly.io
+# - "cloudfront_viewer_address" - AWS CloudFront
+#
+# On Unix-socket deployments, leave this unset rather than setting
+# "connect_info"; that source requires a TCP peer address.
+#
+# WARNING: a header-based value without a trusted reverse proxy in
+# front of tuwunel allows clients to forge their IP. Changing this
+# value requires a server restart.
+#
+#ip_source = "connect_info"
 
 # Grace period for clean shutdown of federation requests (seconds).
 #
@@ -409,10 +515,33 @@ registration_token = "__REGISTRATION_TOKEN__"
 #
 #allow_encryption = true
 
+# Controls whether locally-created rooms should be end-to-end encrypted by
+# default. This option is equivalent to the one found in Synapse.
+#
+# Options:
+# - "all": All created rooms are encrypted.
+# - "invite": Any room created with `private_chat` or
+#   `trusted_private_chat` presets.
+# - "none": Explicit value for no effect.
+# - Other values default to no effect.
+#
+#encryption_enabled_by_default_for_room_type = "none"
+
 # Controls whether federation is allowed or not. It is not recommended to
-# disable this after the fact due to potential federation breakage.
+# disable this after installation due to potential federation breakage but
+# this is technically not a permanent setting.
 #
 allow_federation = __FEDERATION__
+
+# Sets the default `m.federate` property for newly created rooms when the
+# client does not request one. If `allow_federation` is set to false at
+# the same this value is set to false it then always overrides the client
+# requested `m.federate` value to false.
+#
+# Rooms are fixed to the setting at the time of their creation and can
+# never be changed; changing this value only affects new rooms.
+#
+#federate_created_rooms = true
 
 # Allows federation requests to be made to itself
 #
@@ -448,6 +577,28 @@ allow_federation = __FEDERATION__
 # APIs. Set this to false to protect against /publicRooms spiders.
 #
 #allow_public_room_directory_without_auth = false
+
+# Allows room directory searches to match on partial room_id's when the
+# search term starts with '!'.
+#
+#allow_public_room_search_by_id = true
+
+# Set this to false to limit results of rooms when searching by ID to
+# those that would be found by an alias or other query; specifically
+# those listed in the public rooms directory. By default this is set to
+# true allowing any joinable room to match. This satisfies the Principle
+# of Least Expectation when pasting a room_id into a search box with
+# intent to join; many rooms simply opt-out of public listings. Therefor
+# to prevent this feature from abuse, knowledge of several characters of
+# the room_id is required before any results are returned.
+#
+#allow_unlisted_room_search_by_id = true
+
+# Show all local users in user directory. With this set to false, only
+# users in public rooms or those that share a room with the user making
+# the search will be shown.
+#
+#show_all_local_users_in_user_directory = false
 
 # Allow guests/unauthenticated users to access TURN credentials.
 #
@@ -493,20 +644,33 @@ allow_federation = __FEDERATION__
 #allow_room_creation = true
 
 # Set to false to disable users from joining or creating room versions
-# that aren't officially supported by tuwunel.
+# that aren't officially supported by tuwunel. Unstable room versions may
+# have flawed specifications or our implementation may be non-conforming.
+# Correct operation may not be guaranteed, but incorrect operation may be
+# tolerable and unnoticed.
 #
-# tuwunel officially supports room versions 6 - 11.
-#
-# tuwunel has slightly experimental (though works fine in practice)
-# support for versions 3 - 5.
+# tuwunel officially supports room versions 6+. tuwunel has slightly
+# experimental (though works fine in practice) support for versions 3 - 5.
 #
 #allow_unstable_room_versions = true
 
+# Set to true to enable experimental room versions.
+#
+# Unlike unstable room versions these versions are either under
+# development, protype spec-changes, or somehow present a serious risk to
+# the server's operation or database corruption. This is for developer use
+# only.
+#
+#allow_experimental_room_versions = false
+
 # Default room version tuwunel will create rooms with.
 #
-# Per spec, room version 11 is the default.
+# The default is prescribed by the spec, but may be selected by developer
+# recommendation. To prevent stale documentation we no longer list it
+# here. It is only advised to override this if you know what you are
+# doing, and by doing so, updates with new versions are precluded.
 #
-#default_room_version = 11
+#default_room_version =
 
 # This item is undocumented. Please contribute documentation for it.
 #
@@ -607,7 +771,12 @@ allow_federation = __FEDERATION__
 
 # Maximum number of keys to request in each trusted server batch query.
 #
-#trusted_server_batch_size = 1024
+#trusted_server_batch_size = 192
+
+# Maximum number of request batches in flight simultaneously when querying
+# a trusted server.
+#
+#trusted_server_batch_concurrency = 2
 
 # Max log level for tuwunel. Allows debug, info, warn, or error.
 #
@@ -626,6 +795,10 @@ allow_federation = __FEDERATION__
 #
 #log_colors = true
 
+# Sets the log format to compact mode.
+#
+#log_compact = false
+
 # Configures the span events which will be outputted with the log.
 #
 #log_span_events = "none"
@@ -639,6 +812,29 @@ allow_federation = __FEDERATION__
 #
 #log_thread_ids = false
 
+# Redirects logging to standard error (stderr). The default is false for
+# stdout. For those using our systemd features the redirection to stderr
+# occurs as necessary and setting this option should not be required. We
+# offer this option for all other users who desire such redirection.
+#
+#log_to_stderr = false
+
+# Setting to false disables the logging/tracing system at a lower level.
+# In contrast to configuring an empty `log` string where the system is
+# still operating but muted, when this option is false the system was not
+# initialized and is not operating. Changing this option has no effect
+# after startup. This option is intended for developers and expert use
+# only: configuring an empty log string is preferred over using this.
+#
+#log_enable = true
+
+# Setting to false disables the logging/tracing system at a lower level
+# similar to `log_enable`. In this case the system is configured normally,
+# but not registered as the global handler in the final steps. This option
+# is for developers and expert use only.
+#
+#log_global_default = true
+
 # OpenID token expiration/TTL in seconds.
 #
 # These are the OpenID tokens that are primarily used for Matrix account
@@ -650,10 +846,28 @@ allow_federation = __FEDERATION__
 # Allow an existing session to mint a login token for another client.
 # This requires interactive authentication, but has security ramifications
 # as a malicious client could use the mechanism to spawn more than one
-# session.
-# Enabled by default.
+# session. Enabled by default.
 #
 #login_via_existing_session = true
+
+# Whether to enable the login token route to accept login tokens at all.
+# Login tokens may be generated by the server for authorization flows such
+# as SSO; disabling tokens may break such features.
+#
+# This option is distinct from `login_via_existing_session` and does not
+# carry the same security implications; the intent is to leave this
+# enabled while disabling the former to prevent clients from commanding
+# login token creation but without preventing the server from doing so.
+#
+#login_via_token = true
+
+# Whether to enable login using traditional user/password authorization
+# flow.
+#
+# Set this option to false if you intend to allow logging in only using
+# other mechanisms, such as SSO.
+#
+#login_with_password = true
 
 # Login token expiration/TTL in milliseconds.
 #
@@ -662,6 +876,14 @@ allow_federation = __FEDERATION__
 # see login_via_existing_session.
 #
 #login_token_ttl = 120000
+
+# Access token TTL in seconds.
+#
+# For clients that support refresh-tokens, the access-token provided on
+# login will be invalidated after this amount of time and the client will
+# be soft-logged-out until refreshing it.
+#
+#access_token_ttl = 604800
 
 # Static TURN username to provide the client if not using a shared secret
 # ("turn_secret"), It is recommended to use a shared secret over static
@@ -711,8 +933,8 @@ allow_federation = __FEDERATION__
 # registered users join. The rooms specified must be rooms that you have
 # joined at least once on the server, and must be public.
 #
-# example: ["#tuwunel:tuwunel.chat",
-# "!eoIzvAvVwY23LPDay8:tuwunel.chat"]
+# example: ["#tuwunel:grin.hu",
+# "!l2xV0sd51lraysuRcsWVECge4NULaH3g-ou95vgDgiM"]
 #
 #auto_join_rooms = []
 
@@ -746,8 +968,8 @@ allow_federation = __FEDERATION__
 #
 #rocksdb_log_stderr = false
 
-# Max RocksDB `LOG` file size before rotating in bytes. Defaults to 4MB in
-# bytes.
+# Max RocksDB `LOG` file size before rotating. Accepts an integer byte
+# count or a string with SI/IEC suffix such as "4 MiB".
 #
 #rocksdb_max_log_file_size = 4194304
 
@@ -971,12 +1193,38 @@ allow_federation = __FEDERATION__
 #
 #rocksdb_stats_level = 1
 
+# Ignores the list of dropped columns set by developers.
+#
+# This should be set to true when knowingly moving between versions in
+# ways which are not recommended or otherwise forbidden, or for
+# diagnostic and development purposes; requiring preservation across such
+# movements.
+#
+# The developer's list of dropped columns is meant to safely reduce space
+# by erasing data no longer in use. If this is set to true that storage
+# will not be reclaimed as intended.
+#
+#rocksdb_never_drop_columns = false
+
+# Configures RocksDB to not preallocate WAL logs.
+#
+# Normally, RocksDB allocates certain types of files by calling
+# fallocate, writing the file contents, then truncating the logs to the
+# proper size. This causes pathological disk space usage on btrfs due
+# how it interacts with its Copy-on-Write implementation.
+#
+# It is recommended to set this to false if you run the server on btrfs,
+# and not touch it otherwise.
+#
+#rocksdb_allow_fallocate = true
+
 # This is a password that can be configured that will let you login to the
 # server bot account (currently `@conduit`) for emergency troubleshooting
 # purposes such as recovering/recreating your admin room, or inviting
 # yourself back.
 #
-# See https://tuwunel.chat/troubleshooting.html#lost-access-to-admin-room for other ways to get back into your admin room.
+# See https://tuwunel.chat/troubleshooting.html#lost-access-to-admin-room
+# for other ways to get back into your admin room.
 #
 # Once this password is unset, all sessions will be logged out for
 # security purposes.
@@ -988,6 +1236,30 @@ allow_federation = __FEDERATION__
 # This item is undocumented. Please contribute documentation for it.
 #
 #notification_push_path = "/_matrix/push/v1/notify"
+
+# For compatibility and special purpose use only. Setting this option to
+# true will not filter messages sent to pushers based on rules or actions.
+# Everything will be sent to the pusher. This option is offered for
+# several reasons, but should not be necessary:
+# - Bypass to workaround bugs or outdated server-side ruleset support.
+# - Allow clients to evaluate pushrules themselves (due to the above).
+# - Hosting or companies which have custom pushers and internal needs.
+#
+# Note that setting this option to true will not affect the record of
+# notifications found in the notifications pane.
+#
+#push_everything = false
+
+# Setting to false disables the heroes calculation made by sliding and
+# legacy client sync. The heroes calculation is mandated by the Matrix
+# specification and your client may not operate properly unless this
+# option is set to true.
+#
+# This option is intended for custom software deployments seeking purely
+# to minimize unused resources; the overall savings are otherwise
+# negligible.
+#
+#calculate_heroes = true
 
 # Allow local (your server only) presence updates/requests.
 #
@@ -1031,6 +1303,17 @@ allow_federation = __FEDERATION__
 # users.
 #
 #presence_timeout_remote_users = true
+
+# Suppresses push notifications for users marked as active. (Experimental)
+#
+# When enabled, users with `Online` presence and recent activity
+# (based on presence state and sync activity) won’t receive push
+# notifications, reducing duplicate alerts while they're active
+# on another client.
+#
+# Disabled by default to preserve legacy behavior.
+#
+#suppress_push_when_active = false
 
 # Allow receiving incoming read receipts from remote servers.
 #
@@ -1121,6 +1404,12 @@ allow_federation = __FEDERATION__
 #
 #allow_legacy_media = false
 
+# Fallback to requesting legacy unauthenticated media from remote servers.
+# Unauthenticated media was removed in ~2024Q3; enabling this adds
+# considerable federation requests which are unlikely to succeed.
+#
+#request_legacy_media = false
+
 # This item is undocumented. Please contribute documentation for it.
 #
 #freeze_legacy_media = true
@@ -1162,6 +1451,42 @@ allow_federation = __FEDERATION__
 #
 #prune_missing_media = false
 
+# List of storage providers to use for media. Providers can be configured
+# below in respective sections designated by
+# `global.storage_provider.<NAME>.<brand>` where `NAME` can be listed
+# here.
+#
+# For advanced features and future extensions involving multiple providers
+# the list may contain multiple entries. You MUST take note of other
+# configuration options when listing multiple providers or resource
+# duplication costs and poor performance can result.
+#
+# The list defaults to `["media"]` which is an implicit storage provider
+# representing the media directory on the local filesystem. It can be
+# altered by configuring `global.storage_provider.media.local` explicitly
+# or disabled by omitting it from this list entirely. Users with existing
+# deployments are advised to continue listing "media" as a fallback along
+# with their new provider.
+#
+#media_storage_providers = ["media"]
+
+# List of configured storage providers where new media will be sent. When
+# this list is not explicitly configured all entries in
+# `media_storage_providers` are used as default.
+#
+# This list is important for users passively migrating to a new media
+# storage provider by only writing to one while querying the other as a
+# fallback.
+#
+# For example:
+#
+# `media_storage_providers = ["media", "media_on_s3"]`
+# `store_media_on_providers = ["media_on_s3"]`
+#
+# Entries in this list must also be listed in `media_storage_providers`.
+#
+#store_media_on_providers = []
+
 # Vector list of regex patterns of server names that tuwunel will refuse
 # to download remote media from.
 #
@@ -1182,6 +1507,25 @@ allow_federation = __FEDERATION__
 # example: ["badserver\.tld$", "badphrase", "19dollarfortnitecards"]
 #
 #forbidden_remote_server_names = []
+
+# (EXPERIMENTAL) The behavior of this option will change; the
+# _experimental suffix will be removed for that change in an upcoming
+# release.
+#
+# List of allowed server names via regex patterns. This is an allow-list
+# rather than a deny-list with all the same details as its counterpart in
+# `forbidden_remote_server_names`.
+#
+# This feature becomes active when this list has one or more entries;
+# everything not matching is denied. By default it is empty and inactive.
+#
+# Entries in `forbidden_remote_server_names` are still applied after
+# this is applied. This allows you to match e.g. "*\.example\.com" here
+# while still singling out "bad\.example\.com" for exclusion.
+#
+# example: ["badserver\.tld$", "badphrase", "19dollarfortnitecards"]
+#
+#allowed_remote_server_names_experimental = []
 
 # List of forbidden server names via regex patterns that we will block all
 # outgoing federated room directory requests for. Useful for preventing
@@ -1270,8 +1614,8 @@ allow_federation = __FEDERATION__
 #
 #url_preview_url_contains_allowlist = []
 
-# Maximum amount of bytes allowed in a URL preview body size when
-# spidering. Defaults to 256KB in bytes.
+# Maximum body size allowed when spidering a URL for previews. Accepts an
+# integer byte count or a string with SI/IEC suffix such as "256 KB".
 #
 #url_preview_max_spider_size = 256000
 
@@ -1314,6 +1658,32 @@ allow_federation = __FEDERATION__
 # example: ["administrator", "b[a4]dusernam[3e]", "badphrase"]
 #
 #forbidden_usernames = []
+
+# List of server names to deprioritize joining through.
+#
+# If a client requests a join through one of these servers,
+# they will be tried last.
+#
+# Useful for preventing failed joins due to timeouts
+# from a certain homeserver.
+#
+#deprioritize_joins_through_servers = ["matrix\.org"]
+
+# Maximum make_join requests to attempt within each join attempt. Each
+# attempt tries a different server, as each server is only tried once;
+# though retries can occur when the join request as a whole is retried.
+#
+#max_make_join_attempts_per_join_attempt = 48
+
+# Maximum join attempts to conduct per client join request. Each join
+# attempt consists of one or more make_join requests limited above, and a
+# single send_join request. This value allows for additional servers to
+# act as the join-server prior to reporting the last error back to the
+# client, which can be frustrating for users. Therefor the default value
+# is greater than one, but less than excessively exceeding the client's
+# request timeout, though that may not be avoidable in some cases.
+#
+#max_join_attempts_per_join_request = 3
 
 # Retry failed and incomplete messages to remote servers immediately upon
 # startup. This is called bursting. If this is disabled, said messages may
@@ -1396,9 +1766,27 @@ allow_federation = __FEDERATION__
 #
 #admin_room_tag = "m.server_notice"
 
+# Whether to grant the first user to register admin privileges by joining
+# them to the admin room. Note that technically the next user to register
+# when the admin room is empty (or only contains the server-user) is
+# granted, and only when the admin room is enabled.
+#
+#grant_admin_to_first_user = true
+
+# Whether the admin room is created on first startup. Users should not set
+# this to false. Developers can set this to false during integration tests
+# to reduce activity and output.
+#
+#create_admin_room = true
+
+# Whether to enable federation on the admin room. This cannot be changed
+# after the admin room is created.
+#
+#federate_admin_room = true
+
 # Sentry.io crash/panic reporting, performance monitoring/metrics, etc.
 # This is NOT enabled by default. tuwunel's default Sentry reporting
-# endpoint domain is `o4506996327251968.ingest.us.sentry.io`.
+# endpoint domain is `o4509498990067712.ingest.us.sentry.io`.
 #
 #sentry = false
 
@@ -1447,9 +1835,23 @@ allow_federation = __FEDERATION__
 #
 #tokio_console = false
 
-# This item is undocumented. Please contribute documentation for it.
+# Arbitrary argument vector for integration testing. Functionality in the
+# server is altered or informed for the requirements of integration tests.
+# - "smoke" performs a shutdown after startup admin commands rather than
+#   hanging on client handling.
 #
 #test = false
+
+# Indicates the server has started in maintenance mode. Historically
+# maintenance mode has been enabled by the command line argument
+# `--maintenance` which then sets various configuration items such as
+# `listening=false` among others. That is still the case. This option was
+# only added as a single source of truth that `--maintenance` mode is
+# active.
+#
+# This option must never be set manually.
+#
+#maintenance = false
 
 # Controls whether admin room notices like account registrations, password
 # changes, account deactivations, room directory publications, etc will be
@@ -1457,6 +1859,32 @@ allow_federation = __FEDERATION__
 # responses will still be sent.
 #
 #admin_room_notices = true
+
+# Save original events before applying redaction to them.
+#
+# They can be retrieved with `admin debug get-retained-pdu` or MSC2815.
+#
+#save_unredacted_events = true
+
+# Redaction retention period in seconds.
+#
+# By default the unredacted events are stored for 60 days.
+#
+#redaction_retention_seconds = 5184000
+
+# Allows users with `redact` power level to request unredacted events with
+# MSC2815.
+#
+# Server admins can request unredacted events regardless of the value of
+# this option.
+#
+#allow_room_admins_to_request_unredacted_events = true
+
+# Prevents local users from sending redactions.
+#
+# This check does not apply to server admins.
+#
+#disable_local_redactions = false
 
 # Enable database pool affinity support. On supporting systems, block
 # device queue topologies are detected and the request pool is optimized
@@ -1467,8 +1895,7 @@ allow_federation = __FEDERATION__
 # Sets the number of worker threads in the frontend-pool of the database.
 # This number should reflect the I/O capabilities of the system,
 # such as the queue-depth or the number of simultaneous requests in
-# flight. Defaults to 32 or four times the number of CPU cores, whichever
-# is greater.
+# flight. Defaults to 32 times the number of CPU cores.
 #
 # Note: This value is only used if db_pool_affinity is disabled or not
 # detected on the system, otherwise it is determined automatically.
@@ -1485,6 +1912,18 @@ allow_federation = __FEDERATION__
 # queue, since group workers can be scheduled on any of those cores.
 #
 #db_pool_workers_limit = 64
+
+# Limits the total number of workers across all worker groups. When the
+# sum of all groups exceeds this value the worker counts are reduced until
+# this constraint is satisfied.
+#
+# By default this value is only effective on larger systems (e.g. 16+
+# cores) where it will tamper the overall thread-count. The thread-pool
+# model will never achieve hardware capacity but this value can be raised
+# on huge systems if the scheduling overhead is determined to not
+# bottleneck and the worker groups are divided too small.
+#
+#db_pool_max_workers = 2048
 
 # Determines the size of the queues feeding the database's frontend-pool.
 # The size of the queue is determined by multiplying this value with the
@@ -1548,7 +1987,140 @@ allow_federation = __FEDERATION__
 #
 #config_reload_signal = true
 
-[global.tls]
+# Sets the `Access-Control-Allow-Origin` header included by this server in
+# all responses. A list of multiple values can be specified. The default
+# is an empty list. The actual header defaults to `*` upon an empty list.
+#
+# There is no reason to configure this without specific intent. Incorrect
+# values may degrade or disrupt clients.
+#
+#access_control_allow_origin = []
+
+# Backport state-reset security fixes to all room versions.
+#
+# This option applies the State Resolution 2.1 mitigation developed during
+# project Hydra for room version 12 to all prior State Resolution 2.0 room
+# versions (all room versions supported by this server). These mitigations
+# increase resilience to state-resets without any new definition of
+# correctness; therefor it is safe to set this to true for existing rooms.
+#
+# Furthermore, state-reset attacks are not consistent as they result in
+# rooms without any single consensus, therefor it is unnecessary to set
+# this to false to match other servers which set this to false or simply
+# lack support; even if replicating the post-reset state suffered by other
+# servers is somehow desired.
+#
+# This option exists for developer and debug use, and as a failsafe in
+# lieu of hardcoding it.
+#
+#hydra_backports = true
+
+# Delete rooms when the last user from this server leaves. This feature is
+# experimental and for the purpose of least-surprise is not enabled by
+# default but can be enabled for deployments interested in conserving
+# space. It may eventually default to true in a future release.
+#
+# Note that not all pathways which can remove the last local user
+# currently invoke this operation, so in some cases you may find the room
+# still exists.
+#
+#delete_rooms_after_leave = false
+
+# Limits the number of One Time Keys per device (not per-algorithm). The
+# reference implementation maintains 50 OTK's at any given time, therefor
+# our default is at least five times that. There is no known reason for an
+# administrator to adjust this value; it is provided here rather than
+# hardcoding it.
+#
+#one_time_key_limit = 256
+
+# (EXPERIMENTAL) Setting this option to true replaces the list of identity
+# providers displayed on a client's login page with a single button "Sign
+# in with single sign-on" linking to the URL
+# `/_matrix/client/v3/login/sso/redirect`. All configured providers are
+# attempted for authorization. All authorizations associate with the same
+# Matrix user. NOTE: All authorizations must succeed, as there is no
+# reliable way to skip a provider.
+#
+# This option is disabled by default, allowing the client to list
+# configured providers and permitting privacy-conscious users to authorize
+# only their choice.
+#
+# Note that fluffychat always displays a single button anyway. You do not
+# need to enable this to use fluffychat; instead we offer a
+# default-provider option, see `default` in the provider config section.
+#
+#single_sso = false
+
+# Setting this option to true replaces the list of identity providers on
+# the client's login screen with a single button "Sign in with single
+# sign-on" linking to the URL `/_matrix/client/v3/login/sso/redirect`. The
+# deployment is expected to intercept this URL with their reverse-proxy to
+# provide a custom webpage listing providers; each entry linking or
+# redirecting back to one of the configured identity providers at
+# /_matrix/client/v3/login/sso/redirect/<client_id>`.
+#
+# This option defaults to false, allowing the client to generate the list
+# of providers or hide all SSO-related options when none configured.
+#
+#sso_custom_providers_page = false
+
+# From MSC3824:
+# > If the client finds oauth_aware_preferred to be true then, assuming it
+# > supports that auth type, it should present this as the only
+# > login/registration method available to the user.
+#
+#oidc_aware_preferred = false
+
+# Directory containing appservice yaml registration files.
+#
+#appservice_dir = ""
+
+# Skip database migration on startup. This option is intended for
+# developer debugging and testing only. Never set this option to false
+# unless you have been instructed to do so. Setting this option to false
+# may cause permanent damage and permanent loss of data.
+#
+# Any new database migrations will not be applied on startup, and the
+# database schema version will not be adjusted. These migrations and
+# schema changes may be expected by the current codebase but may not be
+# available when this option is set to false.
+#
+# Setting this option to false will have no effect if no new migrations
+# are to be applied. New migrations are applied once during any execution
+# where this option is set to true (which is the default).
+#
+#database_migrations = true
+
+# Force the database to set its version to the current version known to
+# the executable.
+#
+# - When the discovered version is less than the current version any
+#   migrations are applied normally.
+# - When the discovered version is equal to the current version,
+#   unversioned migrations are applied normally.
+# - When the discovered database version is greater than the current
+#   version, one-time migrations are applied normally and the discoverable
+#   version is regressed back to the current version.
+#
+# This option extremely dangerous and intended for developer debugging and
+# testing only. Never set this option unless you have been instructed to
+# do so. Setting this option may cause permanent damage and permanent loss
+# of data.
+#
+#force_migration = false
+
+# Set this to true for excluding unencrypted rooms from the common-rooms
+# calculation deciding the receivers of device list updates.
+#
+# Setting this to true can help performance on very large homeservers,
+# but it may not be spec compliant and risky for client expectations.
+#
+#device_key_update_encrypted_rooms_only = false
+
+
+
+#[global.tls]
 
 # Path to a valid TLS certificate file.
 #
@@ -1566,7 +2138,9 @@ allow_federation = __FEDERATION__
 #
 #dual_protocol = false
 
-[global.well_known]
+
+
+#[global.well_known]
 
 # The server URL that the client well-known file will serve. This should
 # not contain a port, and should just be a valid HTTPS URL.
@@ -1583,23 +2157,64 @@ allow_federation = __FEDERATION__
 #
 #server =
 
-# This item is undocumented. Please contribute documentation for it.
+# The URL of the support web page. This and the below generate the content
+# of `/.well-known/matrix/support`.
+#
+# example: "https://example.com/support"
 #
 #support_page =
 
-# This item is undocumented. Please contribute documentation for it.
+# The name of the support role.
+#
+# example: "m.role.admin"
 #
 #support_role =
 
-# This item is undocumented. Please contribute documentation for it.
+# The email address for the above support role.
+#
+# example: "admin@example.com"
 #
 #support_email =
 
-# This item is undocumented. Please contribute documentation for it.
+# The Matrix User ID for the above support role.
+#
+# example "@admin:example.com"
 #
 #support_mxid =
 
-[global.blurhashing]
+# LiveKit JWT endpoint.
+# Required for Element Call / MatrixRTC (MSC4143).
+#
+# Note: You must also set `client` above to your homeserver URL.
+#
+#livekit_url = ""
+
+# Custom MatrixRTC transports.
+#
+# If you're looking to setup Element Call / MatrixRTC with Livekit,
+# you should not use this option and instead set `livekit_url`.
+# This is only required if you want to configure a non-livekit MatrixRTC
+# transport. There are no known client implementations that support any
+# other transport types.
+#
+# This option was previously the only way to configure a Livekit
+# transport. It has been superseded by `livekit_url`.
+#
+# Example:
+# ```toml
+# [global.well_known]
+# client = "https://matrix.yourdomain.com"
+#
+# [[global.well_known.rtc_transports]]
+# type = "livekit"
+# livekit_service_url = "https://livekit.yourdomain.com"
+# ```
+#
+#rtc_transports = []
+
+
+
+#[global.blurhashing]
 
 # blurhashing x component, 4 is recommended by https://blurha.sh/
 #
@@ -1612,10 +2227,13 @@ allow_federation = __FEDERATION__
 # Max raw size that the server will blurhash, this is the size of the
 # image after converting it to raw data, it should be higher than the
 # upload limit but not too high. The higher it is the higher the
-# potential load will be for clients requesting blurhashes. The default
-# is 33.55MB. Setting it to 0 disables blurhashing.
+# potential load will be for clients requesting blurhashes. Accepts an
+# integer byte count or a string with SI/IEC suffix such as "32 MiB".
+# Setting it to 0 disables blurhashing.
 #
 #blurhash_max_raw_size = 33554432
+
+
 
 [global.ldap]
 
@@ -1648,14 +2266,14 @@ base_dn = "ou=users,dc=yunohost,dc=org"
 # example: "cn=ldap-reader,dc=example,dc=org" or
 # "cn={username},ou=users,dc=example,dc=org"
 #
-#bind_dn = false
+#bind_dn = ""
 
 # Path to a file on the system that contains the password for the
 # `bind_dn`.
 #
 # The server must be able to access the file, and it must not be empty.
 #
-#bind_password_file = false
+#bind_password_file = ""
 
 # Search filter to limit user searches.
 #
@@ -1672,17 +2290,11 @@ filter = "(uid={username})"
 #
 #uid_attribute = "uid"
 
-# Attribute containing the mail of the user.
-#
-# example: "mail"
-#
-#mail_attribute = "mail"
-
 # Attribute containing the distinguished name of the user.
 #
 # example: "givenName" or "sn"
 #
-#name_attribute = "fullName"
+#name_attribute = "givenName"
 
 # Root of the searches for admin users.
 #
@@ -1690,7 +2302,7 @@ filter = "(uid={username})"
 #
 # example: "ou=admins,dc=example,dc=org"
 #
-#admin_base_dn = false
+#admin_base_dn =
 
 # The LDAP search filter to find administrative users for tuwunel.
 #
@@ -1703,3 +2315,482 @@ filter = "(uid={username})"
 # example: "(objectClass=tuwunelAdmin)" or "(uid={username})"
 #
 admin_filter = "(&(uid={username})(permission=cn=__APP__.admin,ou=permission,dc=yunohost,dc=org))"
+
+
+
+#[global.jwt]
+
+# Enable JWT logins
+#
+#enable = false
+
+# Validation key, also called 'secret' in Synapse config. The type of key
+# can be configured in 'format', but defaults to the common HMAC which
+# is a plaintext shared-secret, so you should keep this value private.
+#
+#key =
+
+# Format of the 'key'. Only HMAC, ECDSA, and B64HMAC are supported
+# Binary keys cannot be pasted into this config, so B64HMAC is an
+# alternative to HMAC for properly random secret strings.
+# - HMAC is a plaintext shared-secret private-key.
+# - B64HMAC is a base64-encoded version of HMAC.
+# - ECDSA is a PEM-encoded public-key.
+# - EDDSA is a PEM-encoded Ed25519 public-key.
+#
+#format = "HMAC"
+
+# Automatically create new user from a valid claim, otherwise access is
+# denied for an unknown even with an authentic token.
+#
+#register_user = true
+
+# JWT algorithm
+#
+#algorithm = "HS256"
+
+# Optional audience claim list. The token must claim one or more values
+# from this list when set.
+#
+#audience = []
+
+# Optional issuer claim list. The token must claim one or more values
+# from this list when set.
+#
+#issuer = []
+
+# Require expiration claim in the token. This defaults to false for
+# synapse migration compatibility.
+#
+#require_exp = false
+
+# Require not-before claim in the token. This defaults to false for
+# synapse migration compatibility.
+#
+#require_nbf = false
+
+# Validate expiration time of the token when present. Whether or not it is
+# required depends on require_exp, but when present this ensures the token
+# is not used after a time.
+#
+#validate_exp = true
+
+# Validate not-before time of the token when present. Whether or not it is
+# required depends on require_nbf, but when present this ensures the token
+# is not used before a time.
+#
+#validate_nbf = true
+
+# Bypass validation for diagnostic/debug use only.
+#
+#validate_signature = true
+
+
+
+#[[global.identity_provider]]
+
+# The brand-name of the service (e.g. Apple, Facebook, GitHub, GitLab,
+# Google) or the software (e.g. keycloak, MAS) providing the identity.
+# When a brand is recognized we apply certain defaults to this config
+# for your convenience. For certain brands we apply essential internal
+# workarounds specific to that provider; it is important to configure this
+# field properly when a provider needs to be recognized (like GitHub for
+# example).
+#
+# Several configured providers can share the same brand name. It is not
+# case-sensitive. As a convenience for common simple deployments we can
+# identify this provider by brand in addition to the unique `client_id` if
+# and only if there is a single provider for the brand; see notes for
+# `client_id`.
+#
+#brand =
+
+# The ID of your OAuth application which the provider generates upon
+# registration. This ID then uniquely identifies this configuration
+# instance itself, becoming the identity provider's ID and must be unique
+# and remain unchanged.
+#
+# As a convenience we also identify this config by `brand` if and only if
+# there is a single provider configured for a `brand`. Note carefully that
+# multiple providers configured with the same `brand` is not an error and
+# this provider will simply not be found when querying by `brand`.
+#
+#client_id =
+
+# Secret key the provider generated for you along with the `client_id`
+# above. Unlike the `client_id`, the `client_secret` can be changed here
+# whenever the provider regenerates one for you.
+#
+#client_secret =
+
+# Secret key to use that's read from the file path specified.
+#
+# This takes priority over "client_secret" first, and falls back to
+# "client_secret" if invalid or failed to open.
+#
+# example: "/etc/tuwunel/.client_secret"
+#
+#client_secret_file =
+
+# Issuer URL the provider publishes for you. We have pre-supplied default
+# values for some of the canonical public providers, making this field
+# optional based on the `brand` set above. Otherwise it is required to
+# find self-hosted providers. It must be identical to what is configured
+# and expected by the provider and must never change because we associate
+# identities to it. If the `/.well-known/openid-configuration` is not
+# found behind this URL see `base_path` below as a workaround.
+#
+#issuer_url =
+
+# The callback URL configured when registering the OAuth application with
+# the provider. Tuwunel's callback URL must be strictly formatted exactly
+# as instructed. The URL host must point directly at the matrix server and
+# use the following path:
+# `/_matrix/client/unstable/login/sso/callback/<client_id>` where
+# `<client_id>` is the same one configured for this provider above.
+#
+#callback_url =
+
+# When more than one identity_provider has been configured and
+# `single_sso` is false and `sso_custom_providers_page` is false this will
+# determine the behavior of the `/_matrix/client/v3/login/sso/redirect`
+# endpoint (note the url lacks a trailing `client_id`).
+#
+# When only one identity_provider is configured it will be interpreted
+# as the default and this does not need to be set. Otherwise a default
+# *must* be selected for some clients (e.g. fluffychat) to work properly
+# when the above conditions require it. To operate out-of-the-box we
+# default to one configured provider if none are explicitly default; a
+# warning will be logged on startup for this condition.
+#
+# (EXPERIMENTAL) Multiple providers can be set to default. All providers
+# configured with this option set to `true` will associate with the same
+# Matrix account when a client flows through
+# `/_matrix/client/v3/login/sso/redirect`.
+#
+# When a user authorizes any provider configured default, the flow will
+# include all other providers configured default as well for association.
+# NOTE: authorization must succeed for ALL default providers.
+#
+#default = false
+
+# Optional display-name for this provider instance seen on the login page
+# by users. It defaults to `brand`. When configuring multiple providers
+# using the same `brand` this can be set to distinguish them.
+#
+#name =
+
+# Optional icon for the provider. The canonical providers have a default
+# icon based on the `brand` supplied above when this is not supplied. Note
+# that it uses an MXC url which is curious in the auth-media era and may
+# not be reliable.
+#
+#icon =
+
+# Optional list of scopes to authorize. An empty array does not impose any
+# restrictions from here, effectively defaulting to all scopes you
+# configured for the OAuth application at the provider. This setting
+# allows for restricting to a subset of those scopes for this instance.
+# Note the user can further restrict scopes during their authorization.
+#
+#scope = []
+
+# Optional list of userinfo claims which shape and restrict the way we
+# compute a Matrix UserId for new registrations. Reviewing Tuwunel's
+# documentation will be necessary for a complete description in detail. An
+# empty array imposes no restriction here, avoiding generated fallbacks as
+# much as possible.
+#
+# For simplicity we reserve a claim called "unique" which can be listed
+# alone to ensure *only* generated ID's are used for registrations.
+#
+# Note that listing the claim "sub" has special significance and will take
+# precedence over all other claims, listed or unlisted. "sub" is not
+# normally used to determine a UserId unless explicitly listed here.
+#
+# As of now arbitrary claims cannot be listed here, we only recognize
+# specific hard-coded claims.
+#
+#userid_claims = []
+
+# Trusted providers can cause username conflicts (i.e. account hijacking)
+# but this is precisely how an existing matrix account can be associated
+# with a provider. When this option is set to true, the way we compute a
+# Matrix UserId from userinfo claims is inverted: we find the first
+# matching user and grant access to it. Whereas by default, when set to
+# false, we skip matching users and register the first available username;
+# falling-back to random characters to avoid conflicts.
+#
+# Only set this option to true for providers you self-host and control.
+# Never set this option to true for the public providers such as GitHub,
+# GitLab, etc.
+#
+# Note that associating an existing user with an untrusted provider is
+# still possible but only with the command '!admin query oauth associate'.
+#
+#trusted = false
+
+# Setting this option to false will inhibit unique ID's from being
+# generated as a last-resort when determining a UserId from a provider's
+# claims. In the case of untrusted providers, when all provided claims
+# conflict with existing user accounts, a unique fallback ID needs
+# to be generated for registration to not be denied with an error.
+#
+# Set this option to false if you operate a private server or a trusted
+# identity provider where random UserId's are undesirable; the result of a
+# misconfiguration or other issue where an error is warranted.
+#
+# This option should be set to true for public servers or some users may
+# never be able to register.
+#
+#unique_id_fallbacks = true
+
+# Controls whether new user registration is possible from this provider.
+# When this option is set to false, authorizations from this provider
+# only affect existing users and will never result in a new registration
+# when the claims fail to match any existing user (in the case of trusted
+# providers) or an available username is found (in the case of untrusted
+# providers).
+#
+# Setting this option to false is generally not useful unless there is
+# an explicit reason to do so.
+#
+#registration = true
+
+# Optional extra path components after the issuer_url leading to the
+# location of the `.well-known` directory used for discovery. If the path
+# starts with a slash it will be treated as absolute, meaning overwriting
+# any path in the issuer_url. The path needs to end with a slash. This
+# will be empty for specification-compliant providers. We have supplied
+# any known values based on `brand` (e.g. `login/oauth/` for GitHub).
+#
+#base_path =
+
+# Overrides the `.well-known` location where the provider's openid
+# configuration is found. It is very unlikely you will need to set this;
+# available for developers or special purposes only.
+#
+#discovery_url =
+
+# Overrides the authorize URL requested during the grant phase. This is
+# generally discovered or derived automatically, but may be required as a
+# workaround for any non-standard or undiscoverable provider.
+#
+#authorization_url =
+
+# Overrides the access token URL; the same caveats apply as with the other
+# URL overrides.
+#
+#token_url =
+
+# Overrides the revocation URL; the same caveats apply as with the other
+# URL overrides.
+#
+#revocation_url =
+
+# Overrides the introspection URL; the same caveats apply as with the
+# other URL overrides.
+#
+#introspection_url =
+
+# Overrides the userinfo URL; the same caveats apply as with the other URL
+# overrides.
+#
+#userinfo_url =
+
+# Whether to perform discovery and adjust this provider's configuration
+# accordingly. This defaults to true. When true, it is an error when
+# discovery fails and authorizations will not be attempted to the
+# provider.
+#
+#discovery = true
+
+# The duration in seconds before a grant authorization session expires.
+#
+#grant_session_duration = 300
+
+# Whether to check the redirect cookie during the callback. This is a
+# security feature and should remain enabled. This is available for
+# developers or deployments which cannot tolerate cookies and are willing
+# to tolerate the risks.
+#
+#check_cookie = true
+
+
+
+#[global.storage_provider.<ID>.local]
+
+# Absolute path to this local filesystem storage provider. Technically the
+# provider exists at the filesystem root, and the base_path is prefixed to
+# all objects.
+#
+#base_path =
+
+# Creates the directory on the local filesystem if missing. This is not
+# recommended to prevent misconfigured environments and missing mounts
+# from silently succeeding.
+#
+#create_if_missing = false
+
+# Toggles the preservation of a directory after its last file contents are
+# removed.
+#
+#delete_empty_directories = true
+
+# Enables checks performed at startup determining the usability of the
+# local directory. Failures will abort the server's startup.
+#
+#startup_check = true
+
+
+
+#[global.storage_provider.<ID>.s3]
+
+# Supply an s3 URL e.g. "s3://bucket/path". These URLs may contain one
+# or all of `bucket`, `region`, and `path` . When not supplied, such
+# additional items can be supplied below individually.
+#
+#url =
+
+# The name of the S3 bucket. e.g. "bucketname-123456789-us-west-2-an".
+#
+#bucket =
+
+# The region of the S3 bucket. e.g. "us-west-2".
+#
+#region = "us-east-1"
+
+# Your amazon IAM Key ID with access granted to this bucket.
+# e.g. "ABCDEFG1X1ZZYYXXWWVV"
+#
+#key =
+
+# The secret key component which is approx 40 characters of base64.
+#
+#secret =
+
+# Optional path prefix within the bucket where all our operations will
+# take place.
+#
+#base_path =
+
+# (expert use) Override the location of s3 applied after components of the
+# parsed `url` (or when none set).
+#
+#endpoint =
+
+# (expert use) Override this property useful for some self-hosted
+# environments. By default it is derived when parsing the primary `url`.
+#
+#use_vhost_request = false
+
+# (expert use) Alternative session-token authentication method.
+#
+#token =
+
+# (expert use) Associated SSE-KMS key material.
+#
+#kms =
+
+# (expert use) When configured for the bucket it should be reflected here.
+#
+#use_bucket_key =
+
+# (expert use) Threshold size for switching to Multi-part uploads. This is
+# a quirk of the S3 protocol which requires us to use a different approach
+# for "large" uploads. This value determines what a "large" upload is. The
+# default value should be sufficient for most providers. The value is a
+# parsed string allowing SI or IEC units for convenience.
+#
+#multipart_threshold = 100 MiB
+
+# (expert use) Size of each individual part within a Multi-part upload.
+# Once an upload exceeds `multipart_threshold` the payload is split into
+# parts of this size, each sent as a separate HTTP PUT. Smaller values
+# keep individual requests under per-request timeouts on slow uplinks at
+# the cost of more round-trips. S3 requires every part except the last
+# to be at least 5 MiB. The value is a parsed string allowing SI or IEC
+# units for convenience.
+#
+#multipart_part_size = 10 MiB
+
+# (developer use) Allows relaxing default requirement forcing HTTPS.
+#
+#use_https = true
+
+# (developer_use) Allows skipping request header signatures (will be
+# reejected by AWS).
+#
+#use_signatures = true
+
+# (developer_use) Allows disabling request payload signatures.
+#
+#use_payload_signatures = true
+
+# (developer use) Enables checks performed at startup such as pinging the
+# provider. Failures are considered critical startup errors which abort
+# startup. When set to false, faulty providers are only discovered with
+# first use and will not be fatal errors.
+#
+# Only set this to false if you expect a provider to be down at startup or
+# for development/testing purposes; checks are disabled when the server
+# is started in '--maintenance' mode.
+#
+#startup_check = true
+
+
+
+#[global.appservice.<ID>]
+
+# The URL for the application service.
+#
+# Optionally set to `null` if no traffic is required.
+#
+#url =
+
+# A unique token for application services to use to authenticate requests
+# to Homeservers.
+#
+#as_token =
+
+# A unique token for Homeservers to use to authenticate requests to
+# application services.
+#
+#hs_token =
+
+# The localpart of the user associated with the application service.
+#
+#sender_localpart =
+
+# Whether requests from masqueraded users are rate-limited.
+#
+# The sender is excluded.
+#
+#rate_limited = false
+
+# The external protocols which the application service provides (e.g.
+# IRC).
+#
+#protocols = []
+
+# Whether the application service wants to receive ephemeral data.
+#
+#receive_ephemeral = false
+
+# Whether the application service wants to do device management, as part
+# of MSC4190.
+#
+#device_management = false
+
+
+
+#[[global.appservice.<ID>.<users|rooms|aliases>]]
+
+# Whether this application service has exclusive access to events within
+# this namespace.
+#
+#exclusive = false
+
+# A regular expression defining which values this namespace includes.
+#
+#regex =


### PR DESCRIPTION
## Problem

- Upsteam shipped a lot of new config options

## Solution

- Show these in template, even if we don't typically set these

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
